### PR TITLE
feat:로그아웃 및 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/global/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.likelion.fourthlinethon.team1.cooltime.global.config;
 
-import com.likelion.fourthlinethon.team1.cooltime.global.jwt.JwtAuthenticationFilter;
+import com.likelion.fourthlinethon.team1.cooltime.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,7 +49,7 @@ public class SecurityConfig {
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**")
                     .permitAll()
                     // 인증 없이 허용할 경로들
-                    .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-password", "/api/auth/check-username", "/api/auth/check-nickname")
+                    .requestMatchers("/api/auth/sign-up", "/api/auth/refresh", "/api/auth/sign-in", "/api/auth/check-password", "/api/auth/check-username", "/api/auth/check-nickname")
                     .permitAll()
                     // 그 외 모든 요청은 모두 인증 필요
                     .anyRequest()

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/global/security/JwtAuthenticationFilter.java
@@ -1,7 +1,8 @@
-package com.likelion.fourthlinethon.team1.cooltime.global.jwt;
+package com.likelion.fourthlinethon.team1.cooltime.global.security;
 
 import com.likelion.fourthlinethon.team1.cooltime.auth.exception.AuthErrorCode;
 import com.likelion.fourthlinethon.team1.cooltime.global.exception.CustomException;
+import com.likelion.fourthlinethon.team1.cooltime.global.jwt.JwtProvider;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/controller/AuthController.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/controller/AuthController.java
@@ -3,8 +3,10 @@ package com.likelion.fourthlinethon.team1.cooltime.user.controller;
 import com.likelion.fourthlinethon.team1.cooltime.global.response.BaseResponse;
 import com.likelion.fourthlinethon.team1.cooltime.user.dto.LoginRequest;
 import com.likelion.fourthlinethon.team1.cooltime.user.dto.LoginResponse;
+import com.likelion.fourthlinethon.team1.cooltime.user.dto.RefreshTokenRequest;
 import com.likelion.fourthlinethon.team1.cooltime.user.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.security.core.Authentication;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,5 +26,22 @@ public class AuthController {
     public ResponseEntity<BaseResponse<LoginResponse>> signIn(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.signIn(request);
         return ResponseEntity.ok(BaseResponse.success("로그인 성공", response));
+    }
+
+    @Operation(summary = "토큰 재발급 API", description = "Request Body로 RefreshToken을 전달받아 새로운 AccessToken을 발급합니다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<BaseResponse<LoginResponse>> refreshToken(@RequestBody RefreshTokenRequest request) {
+        LoginResponse response = authService.refreshAccessToken(request.getRefreshToken());
+        return ResponseEntity.ok(BaseResponse.success("AccessToken 재발급 성공", response));
+    }
+
+    // 로그아웃 API (JWT 인증 필터를 통과한 사용자만 가능)
+    @Operation(summary = "로그아웃 API", description = "AccessToken 인증 후 RefreshToken 무효화")
+    @PostMapping("/sign-out")
+    public ResponseEntity<BaseResponse<Void>> logout(Authentication authentication) {
+        // JWT 필터를 통과하면 authentication.getName()에 username이 들어 있음
+        String username = authentication.getName();
+        authService.logout(username);
+        return ResponseEntity.ok(BaseResponse.success("로그아웃 성공", null));
     }
 }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/dto/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package com.likelion.fourthlinethon.team1.cooltime.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshTokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/service/AuthService.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.likelion.fourthlinethon.team1.cooltime.user.service;
 
+import com.likelion.fourthlinethon.team1.cooltime.auth.exception.AuthErrorCode;
 import com.likelion.fourthlinethon.team1.cooltime.global.exception.CustomException;
 import com.likelion.fourthlinethon.team1.cooltime.global.jwt.JwtProvider;
 import com.likelion.fourthlinethon.team1.cooltime.user.dto.LoginRequest;
@@ -47,5 +48,56 @@ public class AuthService {
                 .nickname(user.getNickname())
                 .username(user.getUsername())
                 .build();
+    }
+    /**
+     * ✅ 토큰 재발급
+     */
+    @Transactional
+    public LoginResponse refreshAccessToken(String refreshToken) {
+        log.info("[토큰 재발급 요청] refreshToken = {}", refreshToken);
+
+        // RefreshToken 유효성 검증
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new CustomException(AuthErrorCode.JWT_TOKEN_INVALID);
+        }
+
+        // DB에서 사용자 조회
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.JWT_TOKEN_INVALID));
+
+        // 새 AccessToken 발급
+        String newAccessToken = jwtProvider.createAccessToken(user.getUsername());
+
+        // RefreshToken이 곧 만료될 경우 새로 발급 (optional)
+        long remain = jwtProvider.getExpiration(refreshToken);
+        if (remain < 1000 * 60 * 60 * 24) { // 남은 시간이 1일 이하라면 새로 발급
+            String newRefreshToken = jwtProvider.createRefreshToken(user.getUsername(), String.valueOf(user.getId()));
+            user.updateRefreshToken(newRefreshToken);
+            userRepository.save(user);
+            refreshToken = newRefreshToken;
+        }
+
+        return LoginResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(refreshToken)
+                .nickname(user.getNickname())
+                .username(user.getUsername())
+                .build();
+    }
+
+    /**
+     * ✅ 로그아웃
+     */
+    @Transactional
+    public void logout(String username) {
+        log.info("[로그아웃 요청] username = {}", username);
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        user.updateRefreshToken(null); // refresh_token 제거
+        userRepository.save(user);
+
+        log.info("[로그아웃 완료] username = {}", username);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- #7  

## 📌 작업 내용 및 특이사항
- 로그아웃 API 구현
- 토큰 재발급 API 구현

## 📝 참고사항
- 로그아웃 테스트 시, authorize에 액세스 토큰 기입 필요

## 📚 기타
- 테스트 완료