### PR TITLE
Feat: 문자열 기반 DailyLog 기록토록 구현

### DIFF
--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/DailyLogRequest.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/DailyLogRequest.java
@@ -3,21 +3,24 @@ package com.likelion.fourthlinethon.team1.cooltime.log.dto;
 import com.likelion.fourthlinethon.team1.cooltime.user.entity.MyType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
+@Schema(title = "DailyLogRequest", description = "미룸 기록 작성/수정 요청 DTO")
 public class DailyLogRequest {
 
-    @Schema(description = "오늘 일을 미뤘는지 여부")
+    @Schema(description = "미룸 여부", example = "true")
     private Boolean isPostponed;
 
-    @Schema(description = "미룸 활동 ID 목록")
-    private List<Long> activityIds;
-
-    @Schema(description = "미룸 이유 ID 목록")
-    private List<Long> reasonIds;
-
-    @Schema(description = "기록 시점의 미룸유형")
+    @Schema(description = "유형", example = "PERFECTION")
     private MyType myType;
+
+    @Schema(description = "활동 이름 배열", example = "[\"공부하기\", \"운동하기\"]")
+    private List<String> activities;
+
+    @Schema(description = "이유 이름 배열", example = "[\"귀찮아서\", \"의욕이 없어서\"]")
+    private List<String> reasons;
 }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/repository/ActivityTagRepository.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/repository/ActivityTagRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface ActivityTagRepository extends JpaRepository<ActivityTag, Long> {
     boolean existsByUserAndName(User user, String name);
-    Optional<ActivityTag> findByIdAndUser(Long id, User user);
+    Optional<ActivityTag> findByUserAndName(User user, String name);
 }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/repository/ReasonTagRepository.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/repository/ReasonTagRepository.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 public interface ReasonTagRepository extends JpaRepository<ReasonTag, Long> {
     boolean existsByUserAndName(User user, String name);
-    Optional<ReasonTag> findByIdAndUser(Long id, User user);
 
     List<ReasonTag> findByUserAndIsDefaultTrue(User user);
     Optional<ReasonTag> findByUserAndName(User user, String name);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #33 

## 📌 작업 내용 및 특이사항
- DailyLogRequest의 activityIds, reasonIds → 문자열 리스트(activities, reasons)로 변경
- DailyLogService에서 이름 기반 매핑 로직으로 수정 (findByUserAndName)
- 존재하지 않는 활동/이유 전달 시 예외 처리 (ACTIVITY_NOT_FOUND, REASON_NOT_FOUND)

## 📝 참고사항
- ID 기반 요청은 제거됨
- 문자열 기반으로만 기록 및 수정 가능

## 📚 기타
- 정상 동작 확인 완료 (POST /api/log, PUT /api/log)