### PR TITLE
feat: 활동·이유 태그 삭제 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/controller/ActivityTagController.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/controller/ActivityTagController.java
@@ -35,13 +35,13 @@ public class ActivityTagController {
         return ResponseEntity.ok(BaseResponse.success("활동이 추가되었습니다.", response));
     }
 
-    @Operation(summary = "활동 삭제", description = "사용자가 직접 추가한 활동 항목을 비활성화 처리합니다.")
+    @Operation(summary = "활동 삭제", description = "활동명을 기준으로 비활성화 처리합니다.")
     @DeleteMapping
     public ResponseEntity<BaseResponse<List<ActivityTagResponse>>> deleteActivity(
-            @RequestBody ActivityDeleteRequest request) {
+            @Valid @RequestBody ActivityDeleteRequest request) {
 
         User user = SecurityUtil.getCurrentUser();
-        List<ActivityTagResponse> response = activityTagService.deleteActivity(user, request.getActivityId());
+        List<ActivityTagResponse> response = activityTagService.deleteActivityByName(user, request.getName());
 
         return ResponseEntity.ok(BaseResponse.success("활동이 비활성화되었습니다.", response));
     }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/controller/ReasonTagController.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/controller/ReasonTagController.java
@@ -35,14 +35,14 @@ public class ReasonTagController {
         return ResponseEntity.ok(BaseResponse.success("이유가 추가되었습니다.", response));
     }
 
-    @Operation(summary = "이유 삭제", description = "사용자가 직접 추가한 이유 항목을 비활성화 처리합니다.")
+    @Operation(summary = "이유 삭제", description = "이유명을 기준으로 비활성화 처리합니다.")
     @DeleteMapping
     public ResponseEntity<BaseResponse<List<ReasonTagResponse>>> deleteReason(
             @Valid @RequestBody ReasonDeleteRequest request) {
 
         User user = SecurityUtil.getCurrentUser();
-        List<ReasonTagResponse> response = reasonTagService.deleteReason(user, request.getReasonId());
+        List<ReasonTagResponse> response = reasonTagService.deleteReasonByName(user, request.getName());
 
-        return ResponseEntity.ok(BaseResponse.success("이유가 삭제(비활성화)되었습니다.", response));
+        return ResponseEntity.ok(BaseResponse.success("이유가 비활성화되었습니다.", response));
     }
 }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/controller/TagController.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/controller/TagController.java
@@ -1,0 +1,51 @@
+package com.likelion.fourthlinethon.team1.cooltime.log.controller;
+
+import com.likelion.fourthlinethon.team1.cooltime.global.response.BaseResponse;
+import com.likelion.fourthlinethon.team1.cooltime.log.dto.ActivityTagResponse;
+import com.likelion.fourthlinethon.team1.cooltime.log.dto.ReasonTagResponse;
+import com.likelion.fourthlinethon.team1.cooltime.log.dto.TagResponse;
+import com.likelion.fourthlinethon.team1.cooltime.log.entity.ActivityTag;
+import com.likelion.fourthlinethon.team1.cooltime.log.entity.ReasonTag;
+import com.likelion.fourthlinethon.team1.cooltime.log.repository.ActivityTagRepository;
+import com.likelion.fourthlinethon.team1.cooltime.log.repository.ReasonTagRepository;
+import com.likelion.fourthlinethon.team1.cooltime.user.entity.User;
+import com.likelion.fourthlinethon.team1.cooltime.global.security.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Tag", description = "활성화된 활동 및 이유 태그 조회 API")
+@RestController
+@RequestMapping("/api/tag")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final ActivityTagRepository activityTagRepository;
+    private final ReasonTagRepository reasonTagRepository;
+
+    @Operation(summary = "활성화된 활동 및 이유 태그 조회", description = "JWT 토큰 기반으로 해당 사용자의 활성화된 활동과 이유를 모두 반환합니다.")
+    @GetMapping
+    public ResponseEntity<BaseResponse<TagResponse>> getActiveTags() {
+        User user = SecurityUtil.getCurrentUser();
+
+        List<ActivityTagResponse> activities = activityTagRepository.findAll().stream()
+                .filter(t -> t.getUser().getId().equals(user.getId()) && t.getIsActive())
+                .map(ActivityTagResponse::fromEntity)
+                .toList();
+
+        List<ReasonTagResponse> reasons = reasonTagRepository.findAll().stream()
+                .filter(r -> r.getUser().getId().equals(user.getId()) && r.getIsActive())
+                .map(ReasonTagResponse::fromEntity)
+                .toList();
+
+        TagResponse response = new TagResponse(activities, reasons);
+
+        return ResponseEntity.ok(BaseResponse.success("활성화된 활동 및 이유 태그 조회 성공", response));
+    }
+}

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/ActivityDeleteRequest.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/ActivityDeleteRequest.java
@@ -1,16 +1,14 @@
 package com.likelion.fourthlinethon.team1.cooltime.log.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@Schema(description = "활동 삭제 요청 DTO")
+@Schema(title = "활동 삭제 요청 DTO", description = "삭제할 활동의 이름을 담는 요청입니다.")
 public class ActivityDeleteRequest {
 
-    @NotNull(message = "삭제할 활동 ID는 필수입니다.")
-    @Schema(description = "활동 ID", example = "2")
-    private Long activityId;
+    @Schema(description = "삭제할 활동 이름", example = "등교하기")
+    @NotBlank(message = "삭제할 활동 이름은 필수입니다.")
+    private String name;
 }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/ReasonDeleteRequest.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/ReasonDeleteRequest.java
@@ -1,11 +1,14 @@
 package com.likelion.fourthlinethon.team1.cooltime.log.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
+@Schema(title = "이유 삭제 요청 DTO", description = "삭제할 이유의 이름을 담는 요청입니다.")
 public class ReasonDeleteRequest {
 
-    @Schema(description = "삭제할 이유 ID")
-    private Long reasonId;
+    @Schema(description = "삭제할 이유 이름", example = "귀찮아서")
+    @NotBlank(message = "삭제할 이유 이름은 필수입니다.")
+    private String name;
 }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/TagResponse.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/dto/TagResponse.java
@@ -1,0 +1,19 @@
+package com.likelion.fourthlinethon.team1.cooltime.log.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(title = "활동 및 이유 태그 통합 응답 DTO", description = "활성화된 활동 및 이유 목록을 전부 반환합니다.")
+public class TagResponse {
+
+    @Schema(description = "활성화된 활동 목록")
+    private List<ActivityTagResponse> activities;
+
+    @Schema(description = "활성화된 이유 목록")
+    private List<ReasonTagResponse> reasons;
+}

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/exception/DailyLogErrorCode.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/exception/DailyLogErrorCode.java
@@ -13,7 +13,9 @@ public enum DailyLogErrorCode implements BaseErrorCode {
     LOG_NOT_FOUND("LOG_404", "오늘 기록이 아직 없습니다.", HttpStatus.NOT_FOUND),
     ACTIVITY_NOT_FOUND("ACTIVITY_404", "해당 활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     REASON_NOT_FOUND("REASON_404", "해당 이유를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    INVALID_DATE("LOG_400", "중복 기록은 불가합니다.", HttpStatus.BAD_REQUEST);
+    ALREADY_INACTIVE_TAG("ALREADY_INACTIVE_TAG", "이미 비활성화된 항목입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DATE("LOG_400", "중복 기록은 불가합니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_DELETE_DEFAULT_TAG("CANNOT_DELETE_DEFAULT_TAG", "기본값(default) 항목은 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/service/ActivityTagService.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/service/ActivityTagService.java
@@ -65,22 +65,20 @@ public class ActivityTagService {
      * 활동 삭제 (default 불가, isActive=false 후 전체 활성 활동 반환)
      */
     @Transactional
-    public List<ActivityTagResponse> deleteActivity(User user, Long activityId) {
-        ActivityTag activity = activityTagRepository.findById(activityId)
+    public List<ActivityTagResponse> deleteActivityByName(User user, String name) {
+        ActivityTag activity = activityTagRepository.findByUserAndName(user, name)
                 .orElseThrow(() -> new CustomException(DailyLogErrorCode.ACTIVITY_NOT_FOUND));
 
-        if (!activity.getUser().getId().equals(user.getId())) {
-            throw new CustomException(DailyLogErrorCode.ACTIVITY_NOT_FOUND);
-        }
-
         if (activity.getIsDefault()) {
-            throw new CustomException(DailyLogErrorCode.ACTIVITY_OR_REASON_ALREADY_EXISTS);
+            throw new CustomException(DailyLogErrorCode.CANNOT_DELETE_DEFAULT_TAG);
+        }
+        if (!activity.getIsActive()) {
+            throw new CustomException(DailyLogErrorCode.ALREADY_INACTIVE_TAG);
         }
 
         activity.setIsActive(false);
         activityTagRepository.save(activity);
 
-        // ✅ 삭제 후에도 활성화된 전체 리스트 반환
         return getActiveTags(user);
     }
 

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/service/ReasonTagService.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/log/service/ReasonTagService.java
@@ -65,16 +65,15 @@ public class ReasonTagService {
      * 이유 삭제 (default 불가, isActive=false 후 전체 활성 이유 반환)
      */
     @Transactional
-    public List<ReasonTagResponse> deleteReason(User user, Long reasonId) {
-        ReasonTag reason = reasonTagRepository.findById(reasonId)
+    public List<ReasonTagResponse> deleteReasonByName(User user, String name) {
+        ReasonTag reason = reasonTagRepository.findByUserAndName(user, name)
                 .orElseThrow(() -> new CustomException(DailyLogErrorCode.REASON_NOT_FOUND));
 
-        if (!reason.getUser().getId().equals(user.getId())) {
-            throw new CustomException(DailyLogErrorCode.REASON_NOT_FOUND);
-        }
-
         if (reason.getIsDefault()) {
-            throw new CustomException(DailyLogErrorCode.ACTIVITY_OR_REASON_ALREADY_EXISTS);
+            throw new CustomException(DailyLogErrorCode.CANNOT_DELETE_DEFAULT_TAG);
+        }
+        if (!reason.getIsActive()) {
+            throw new CustomException(DailyLogErrorCode.ALREADY_INACTIVE_TAG);
         }
 
         reason.setIsActive(false);

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/controller/UserController.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/controller/UserController.java
@@ -59,7 +59,7 @@ public class UserController {
             @RequestParam String username) {
 
         // 정규식 검증 (4~12자 영문+숫자)
-        if (!username.matches("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{4,12}$")) {
+        if (!username.matches("^[A-Za-z\\d]{4,12}$")) {
             return ResponseEntity.badRequest()
                     .body(BaseResponse.error("아이디는 4~12자의 영문과 숫자 조합이어야 합니다."));
         }

--- a/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/dto/SignUpRequest.java
+++ b/src/main/java/com/likelion/fourthlinethon/team1/cooltime/user/dto/SignUpRequest.java
@@ -17,7 +17,7 @@ public class SignUpRequest {
     )
     @NotBlank(message = "아이디는 필수 입력 항목입니다.")
     @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{4,12}$",
+            regexp = "^[A-Za-z\\d]{4,12}$",
             message = "아이디는 4~12자의 영문과 숫자 조합이어야 합니다."
     )
     private String username;
@@ -28,8 +28,8 @@ public class SignUpRequest {
     )
     @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
     @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{8,20}$",
-            message = "비밀번호는 8~20자의 영문, 숫자, 특수문자 2종 이상을 포함해야 합니다."
+            regexp = "^(?=(?:.*[A-Za-z].*)(?:.*\\d.*)|(?:.*[A-Za-z].*)(?:.*[!@#$%^&*()_+=-].*)|(?:.*\\d.*)(?:.*[!@#$%^&*()_+=-].*)).{8,20}$",
+            message = "비밀번호는 8~20자의 영문, 숫자, 특수문자 중 2종 이상을 포함해야 합니다."
     )
     private String password;
 


### PR DESCRIPTION
## 🌱 관련 이슈
- #36 

## 📌 작업 내용 및 특이사항
- 활동(Activity) / 이유(Reason) 삭제 API 수정
- 활성화된 태그 조회 API 추가 (GET /api/tag)
- 예외 처리 개선
- 회원가입 비밀번호 로직 개선

## 📝 참고사항
- 테스트 결과 확인 완료
